### PR TITLE
Lock postgresql to v13 to match production

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -5,7 +5,7 @@ tap "homebrew/services"
 tap "puma/puma"
 
 brew "nvm"
-brew "postgresql@14", restart_service: true
+brew "postgresql@13", restart_service: true
 brew "redis", restart_service: true
 brew "yarn"
 brew "heroku"


### PR DESCRIPTION
* you may need to run `brew link postgresql@13`
* you may then want to do `brew pin postgresql@13` to prevent it from being upgraded in the future
* in the worst case, do the following:

```
$ brew services stop postgresql
$ brew uninstall postgresql@14
$ brew link postgresql@13
$ brew services start postgresql
```

* I also needed to run `bundle pristine pg` to re-build that gem with old postgres libs.