### PR TITLE
🔥 Remove NVM

### DIFF
--- a/.start_nvm
+++ b/.start_nvm
@@ -1,3 +1,0 @@
-export NVM_DIR="$HOME/.nvm"
-  [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"  # This loads nvm
-  [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"  # This loads nvm bash_completion

--- a/Brewfile
+++ b/Brewfile
@@ -4,7 +4,6 @@ tap "homebrew/core"
 tap "homebrew/services"
 tap "puma/puma"
 
-brew "nvm"
 brew "postgresql@13", restart_service: true
 brew "redis", restart_service: true
 brew "yarn"

--- a/platform_setup.sh
+++ b/platform_setup.sh
@@ -44,20 +44,12 @@ else
   source brew.sh
 fi
 
-echo "Creating NVM's working directory if it doesn't exist..."
-mkdir -p ~/.nvm
-
 echo "Load Homebrew when the shell starts..."
 append_file 'eval "$(/opt/homebrew/bin/brew shellenv)"'
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
 echo "Installing Brewfile..."
 brew bundle --no-upgrade
-
-echo "Load NVM when the shell starts..."
-cp -np .start_nvm ~
-append_file "source ~/.start_nvm"
-source .start_nvm
 
 echo "Add Heroku Multiple Accounts Plugin..."
 heroku plugins:install heroku-accounts


### PR DESCRIPTION
Remove NVM setup, @kranzky has already implemented `nodenv` for us and it is much better (installed and configured as part of the `setup_dev.sh` script in the valiant repo). Remove the legacy NVM setup from here to avoid confusion.